### PR TITLE
Text2Image (will take about 17 GB of VRAM) Readme.md usage updated / DemoFusionSDXLPipeline class docstring fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pip install -r requirements.txt
 - Download `pipeline_demofusion_sdxl.py` and run it as follows. A use case can be found in `demo.ipynb`.
 ```
 from pipeline_demofusion_sdxl import DemoFusionSDXLPipeline
+import torch
 
 model_ckpt = "stabilityai/stable-diffusion-xl-base-1.0"
 pipe = DemoFusionSDXLPipeline.from_pretrained(model_ckpt, torch_dtype=torch.float16)

--- a/pipeline_demofusion_sdxl.py
+++ b/pipeline_demofusion_sdxl.py
@@ -105,7 +105,7 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
 
 
 class DemoFusionSDXLPipeline(DiffusionPipeline, FromSingleFileMixin, LoraLoaderMixin, TextualInversionLoaderMixin):
-    r"""
+    """
     Pipeline for text-to-image generation using Stable Diffusion XL.
 
     This model inherits from [`DiffusionPipeline`]. Check the superclass documentation for the generic methods the


### PR DESCRIPTION
"import torch" added.