### PR TITLE
fix error when there is no `image_lr` but lowres mode tries to move i…

### DIFF
--- a/pipeline_demofusion_sdxl_controlnet.py
+++ b/pipeline_demofusion_sdxl_controlnet.py
@@ -1051,7 +1051,8 @@ class DemoFusionSDXLControlNetPipeline(
             self.unet.cpu()
             self.text_encoder.to(device)
             self.text_encoder_2.to(device)
-            image_lr.cpu()
+            if image_lr:
+                image_lr.cpu()
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.


### PR DESCRIPTION
…t to cpu.

If `lowres=True` but `image_lr` is `None` the pipeline errors when it tries to move it to the cpu.